### PR TITLE
Escape Index names so that special characters are allowed in Indexes also

### DIFF
--- a/IDBDatabase.js
+++ b/IDBDatabase.js
@@ -143,7 +143,7 @@ if (window.indexedDB.polyfill)
         sqlTx.executeSql("CREATE TABLE [" + name + "] (id INTEGER PRIMARY KEY AUTOINCREMENT, " +
           "key BLOB UNIQUE, value BLOB)", null, null, errorCallback);
 
-        sqlTx.executeSql("CREATE INDEX INDEX_" + name + "_key ON [" + name + "] (key)", null, null, errorCallback);
+        sqlTx.executeSql("CREATE INDEX [INDEX_" + name + "_key] ON [" + name + "] (key)", null, null, errorCallback);
 
         sqlTx.executeSql("INSERT INTO " + indexedDB.SCHEMA_TABLE +
           " (type, name, keyPath, autoInc) VALUES ('table', ?, ?, ?)",

--- a/IDBObjectStore.js
+++ b/IDBObjectStore.js
@@ -421,10 +421,10 @@ if (window.indexedDB.polyfill)
       };
       me.transaction._queueOperation(function (sqlTx, nextRequestCallback) {
         var indexTable = util.indexTable(me.name, name);
-        sqlTx.executeSql("CREATE TABLE " + indexTable + " (recordId INTEGER, key BLOB" +
+        sqlTx.executeSql("CREATE TABLE [" + indexTable + "] (recordId INTEGER, key BLOB" +
           (unique ? " UNIQUE" : "") + ", primaryKey BLOB)", null, null, errorCallback);
 
-        sqlTx.executeSql("CREATE INDEX INDEX_" + indexTable + "_key ON [" + indexTable + "] (key)",
+        sqlTx.executeSql("CREATE INDEX [INDEX_" + indexTable + "_key] ON [" + indexTable + "] (key)",
           null, null, errorCallback);
 
         sqlTx.executeSql("INSERT INTO " + indexedDB.SCHEMA_TABLE +

--- a/indexedDB.polyfill.js
+++ b/indexedDB.polyfill.js
@@ -575,7 +575,7 @@
       sqlTx.executeSql("CREATE TABLE [" + name + "] (id INTEGER PRIMARY KEY AUTOINCREMENT, " +
         "key BLOB UNIQUE, value BLOB)", null, null, errorCallback);
 
-      sqlTx.executeSql("CREATE INDEX INDEX_" + name + "_key ON [" + name + "] (key)", null, null, errorCallback);
+      sqlTx.executeSql("CREATE INDEX [INDEX_" + name + "_key] ON [" + name + "] (key)", null, null, errorCallback);
 
       sqlTx.executeSql("INSERT INTO " + indexedDB.SCHEMA_TABLE +
         " (type, name, keyPath, autoInc) VALUES ('table', ?, ?, ?)",
@@ -1397,10 +1397,10 @@
     };
     me.transaction._queueOperation(function (sqlTx, nextRequestCallback) {
       var indexTable = util.indexTable(me.name, name);
-      sqlTx.executeSql("CREATE TABLE " + indexTable + " (recordId INTEGER, key BLOB" +
+      sqlTx.executeSql("CREATE TABLE [" + indexTable + "] (recordId INTEGER, key BLOB" +
         (unique ? " UNIQUE" : "") + ", primaryKey BLOB)", null, null, errorCallback);
 
-      sqlTx.executeSql("CREATE INDEX INDEX_" + indexTable + "_key ON [" + indexTable + "] (key)",
+      sqlTx.executeSql("CREATE INDEX [INDEX_" + indexTable + "_key] ON [" + indexTable + "] (key)",
         null, null, errorCallback);
 
       sqlTx.executeSql("INSERT INTO " + indexedDB.SCHEMA_TABLE +
@@ -1918,7 +1918,7 @@
           if (callback) callback(new Transaction(tx), resultSet);
         },
         function (tx, error) {
-          console.error("[SQL Error]: ", error);
+          console.error("[SQL Error]: ", error, sql);
           if (errorCallback) errorCallback(new Transaction(tx), wrapSqlError(error));
         });
     }

--- a/webSql.js
+++ b/webSql.js
@@ -82,7 +82,7 @@ if (window.indexedDB.polyfill)
             if (callback) callback(new Transaction(tx), resultSet);
           },
           function (tx, error) {
-            console.error("[SQL Error]: ", error);
+            console.error("[SQL Error]: ", error, sql);
             if (errorCallback) errorCallback(new Transaction(tx), wrapSqlError(error));
           });
       }


### PR DESCRIPTION
- Also added SQL statement when SQL error occurs

Was geting IndexedDB polyfill integrated with pouchdb (pouchdb.js), noticed this error. Had the same error in my IndexedDB also - https://github.com/axemclion/IndexedDBShim/commit/df8e5cb1c6366454546826a2f43a0e391c8ec2b8
