### PR TITLE
bad keyPath for indices created from WebSQL data

### DIFF
--- a/indexedDB.polyfill.js
+++ b/indexedDB.polyfill.js
@@ -545,7 +545,7 @@
             }
             objectStore.indexNames.push(item.name);
             objectStore._indexes[item.name] = new util.IDBIndex(objectStore,
-              item.name, item.keyPath, item.unique, item.multiEntry)
+              item.name, w_JSON.parse(item.keyPath), item.unique, item.multiEntry)
           }
         }
         if (successCallback) successCallback();

--- a/indexedDB.polyfill.js
+++ b/indexedDB.polyfill.js
@@ -1855,8 +1855,6 @@
   var DEFAULT_DB_SIZE = 5 * 1024 * 1024;
 
   /**
-   * ADDED BY POLOPOLY (2013-12-18):
-   *
    * Since Safari (both Mobile and Desktop version) doesn't seem to perform GC on native WebSQL
    * database objects, we cache them ourselves here. Otherwise you will run into some internal
    * limit for open connectons / file locks in either Safari or SQLite.

--- a/indexedDB.polyfill.js
+++ b/indexedDB.polyfill.js
@@ -1854,8 +1854,22 @@
   /* webSql.js */
   var DEFAULT_DB_SIZE = 5 * 1024 * 1024;
 
+  /**
+   * ADDED BY POLOPOLY (2013-12-18):
+   *
+   * Since Safari (both Mobile and Desktop version) doesn't seem to perform GC on native WebSQL
+   * database objects, we cache them ourselves here. Otherwise you will run into some internal
+   * limit for open connectons / file locks in either Safari or SQLite.
+   */
+
+  var webSQLDatabases = {};
+
   util.openDatabase = function (name) {
-    return new Database(window.openDatabase(indexedDB.DB_PREFIX + name, "", "IndexedDB " + name, DEFAULT_DB_SIZE));
+    if(!webSQLDatabases[name]) {
+      webSQLDatabases[name] = window.openDatabase(indexedDB.DB_PREFIX + name, "", "IndexedDB " + name, DEFAULT_DB_SIZE);
+    }
+
+    return new Database(webSQLDatabases[name]);
   };
 
   var Database_prototype = function (db) {

--- a/lib/qunit.js
+++ b/lib/qunit.js
@@ -1467,7 +1467,7 @@ QUnit.equiv = (function() {
  */
 QUnit.jsDump = (function() {
 	function quote( str ) {
-		return '"' + encodedKey.toString().replace( /"/g, '\\"' ) + '"';
+		return '"' + str.toString().replace( /"/g, '\\"' ) + '"';
 	}
 	function literal( o ) {
 		return o + "";
@@ -1824,19 +1824,19 @@ QUnit.diff = (function() {
 
 		if ( out.n.length === 0 ) {
 			for ( i = 0; i < out.o.length; i++ ) {
-				encodedKey += "<del>" + out.o[i] + oSpace[i] + "</del>";
+				str += "<del>" + out.o[i] + oSpace[i] + "</del>";
 			}
 		}
 		else {
 			if ( out.n[0].text == null ) {
 				for ( n = 0; n < out.o.length && out.o[n].text == null; n++ ) {
-					encodedKey += "<del>" + out.o[n] + oSpace[n] + "</del>";
+					str += "<del>" + out.o[n] + oSpace[n] + "</del>";
 				}
 			}
 
 			for ( i = 0; i < out.n.length; i++ ) {
 				if (out.n[i].text == null) {
-					encodedKey += "<ins>" + out.n[i] + nSpace[i] + "</ins>";
+					str += "<ins>" + out.n[i] + nSpace[i] + "</ins>";
 				}
 				else {
 					// `pre` initialized at top of scope
@@ -1845,12 +1845,12 @@ QUnit.diff = (function() {
 					for ( n = out.n[i].row + 1; n < out.o.length && out.o[n].text == null; n++ ) {
 						pre += "<del>" + out.o[n] + oSpace[n] + "</del>";
 					}
-					encodedKey += " " + out.n[i].text + nSpace[i] + pre;
+					str += " " + out.n[i].text + nSpace[i] + pre;
 				}
 			}
 		}
 
-		return encodedKey;
+		return str;
 	};
 }());
 

--- a/test/IDBIndexTests.js
+++ b/test/IDBIndexTests.js
@@ -67,7 +67,7 @@ var IDBIndexTests = new (function () {
   }
 
   function testOpenCursor(db) {
-    expect(6);
+    expect(7);
     var tx = db.transaction([env.people.name]);
     tx.error = util.shouldNotReachHereCallback;
     tx.oncomplete = function (e) {
@@ -77,6 +77,7 @@ var IDBIndexTests = new (function () {
     var people = tx.objectStore(env.people.name);
     var range = IDBKeyRange.bound("n1", "n4", true);
     var request = people.index(env.nameIndex).openCursor(range, IDBCursor.NEXT_NO_DUPLICATE);
+    deepEqual(people.index(env.nameIndex).keyPath, "name", "keyPath should match");
     request.onerror = util.shouldNotReachHereCallback;
     var i = -1, ii = [3, 4, 2];
     request.onsuccess = function (e) {


### PR DESCRIPTION
Indices generated from WebSQL data have unparsed JSON for keyPath.

If the index was created via `IDBObjectStore.createIndex`, then it is fine. However once the page is reloaded and the index is recreated via `IDBDatabase._loadObjectStores` then it has the wrong keyPath. No error is reported, but the index is never updated for new and updated records.
