### PR TITLE
Cache native WebSQL database objects

### DIFF
--- a/indexedDB.polyfill.js
+++ b/indexedDB.polyfill.js
@@ -1855,8 +1855,6 @@
   var DEFAULT_DB_SIZE = 5 * 1024 * 1024;
 
   /**
-   * ADDED BY POLOPOLY (2013-12-18):
-   *
    * Since Safari (both Mobile and Desktop version) doesn't seem to perform GC on native WebSQL
    * database objects, we cache them ourselves here. Otherwise you will run into some internal
    * limit for open connectons / file locks in either Safari or SQLite.

--- a/indexedDB.polyfill.js
+++ b/indexedDB.polyfill.js
@@ -1854,8 +1854,22 @@
   /* webSql.js */
   var DEFAULT_DB_SIZE = 5 * 1024 * 1024;
 
+  /**
+   * ADDED BY POLOPOLY (2013-12-18):
+   *
+   * Since Safari (both Mobile and Desktop version) doesn't seem to perform GC on native WebSQL
+   * database objects, we cache them ourselves here. Otherwise you will run into some internal
+   * limit for open connectons / file locks in either Safari or SQLite.
+   */
+
+  var webSQLDatabases = {};
+
   util.openDatabase = function (name) {
-    return new Database(window.openDatabase(indexedDB.DB_PREFIX + name, "", "IndexedDB " + name, DEFAULT_DB_SIZE));
+    if(!webSQLDatabases[name]) {
+      webSQLDatabases[name] = window.openDatabase(indexedDB.DB_PREFIX + name, "", "IndexedDB " + name, DEFAULT_DB_SIZE);
+    }
+
+    return new Database(webSQLDatabases[name]);
   };
 
   var Database_prototype = function (db) {


### PR DESCRIPTION
I recently ran into an issue where Safari 7 would, after a while, fail to work with WebSQL databases. After investigating, it seemed that the number of concurrent handles towards the WebSQL database exceeded some internal limit, and after that Safari would simply not play nice anymore. Caching the native WebSQL database object seems to do the trick.
